### PR TITLE
Fixed publish_at, expire_at in backend crud

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ Config
 ...
 'modules => [
 	'widgets' => [
-		'class'						=> '\hrzg\widget\Module',
-		'layout'					=> '@backend/views/layouts/main',
-		'playgroundLayout'			=> '@frontend/views/layouts/main',
-		'dateBasedAccessControl'	=> true,
-		'datepickerMinutes'			=> false
+		'class' => '\hrzg\widget\Module',
+		'layout' => '@backend/views/layouts/main',
+		'playgroundLayout' => '@frontend/views/layouts/main',
+		'dateBasedAccessControl' => true,
+		'datepickerMinutes' => false,
+		'timezone' => 'Europe/Berlin'
 	]
 ]
 ...

--- a/src/Module.php
+++ b/src/Module.php
@@ -60,6 +60,12 @@ class Module extends \yii\base\Module
     public $datepickerMinutes = false;
 
     /**
+     * timezone for DateTime objects
+     * @var 'string
+     */
+    public $timezone = 'UTC';
+
+    /**
      * @param \yii\base\Action $action
      *
      * @return bool

--- a/src/assets/web/widgets-init.js
+++ b/src/assets/web/widgets-init.js
@@ -132,36 +132,7 @@ editor.on('change', function () {
 
 });
 
-
 $(document).on('pjax:complete', function () {
     console.log('template: reload success');
     editor.trigger('change');
-});
-
-$(document).on('ready', function() {
-    // set timezone in hidden input
-    var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    $('#widgetcontent-timezone').val(timezone);
-
-    // Calculate utc time from db into client local time
-    var publishAtInput = $('#widgetcontent-publish_at');
-    var expireAtInput = $('#widgetcontent-expire_at');
-
-    function toLocalDate(utcDate) {
-        var dateWithoutOffset = new Date(utcDate.getTime() - utcDate.getTimezoneOffset()*60*1000);
-        return dateWithoutOffset.toISOString().substr(0, 16).replace('T', ' ')
-    }
-
-    var publicationDate = new Date(publishAtInput.val());
-    if(!isNaN(publicationDate.getTime())) {
-        var publicationDateWithTimezone = toLocalDate(publicationDate);
-        // the color change prevents input flickering of utc time
-        publishAtInput.val(publicationDateWithTimezone).css('color', '#555');
-    }
-
-    var expirationDate = new Date(expireAtInput.val());
-    if(!isNaN(expirationDate.getTime())) {
-        var expirationDateWithTimezone = toLocalDate(expirationDate);
-        expireAtInput.val(expirationDateWithTimezone).css('color', '#555');
-    }
 });

--- a/src/controllers/crud/base/WidgetController.php
+++ b/src/controllers/crud/base/WidgetController.php
@@ -176,7 +176,7 @@ class WidgetController extends Controller
         }
 
         return $this->render('update', [
-            'model' => $this->findModel($id),
+            'model' => $model,
             'schema' => $this->getJsonSchema($model),
         ]);
     }

--- a/src/views/crud/widget/_form.php
+++ b/src/views/crud/widget/_form.php
@@ -140,13 +140,14 @@ JS;
                 <?php if(\Yii::$app->controller->module->dateBasedAccessControl) { ?>
 
                     <?php
-                        // sets $startday with the current date by timezone.
-                        // the timezone can be configured in the widgets module.
-                        // the default timezone is "UTC"
-                        $timezone = \Yii::$app->getModule('widgets')->timezone;
-                        $dateByTimeZone = new \DateTime(null, new \DateTimeZone($timezone));
-                        $dateByTimeZone->add(new DateInterval('PT5M')); // add 5 extra minutes
-                        $startDate = $dateByTimeZone->format('Y-m-d H:i');
+                    // sets $startday with the current date by timezone.
+                    // the timezone can be configured in the widgets module.
+                    // the default timezone is "UTC"
+                    $timezone = \Yii::$app->getModule('widgets')->timezone;
+                    $dateByTimeZone = new \DateTime(null, new \DateTimeZone($timezone));
+                    // add 1 extra minutes. ex: cannot set 09:10 when 09:10.
+                    $dateByTimeZone->add(new DateInterval('PT1M'));
+                    $startDate = $dateByTimeZone->format('Y-m-d H:i');
                     ?>
 
                 <div class="panel-heading">

--- a/src/views/crud/widget/_form.php
+++ b/src/views/crud/widget/_form.php
@@ -138,9 +138,20 @@ JS;
                     <?= $form->field($model, 'status')->checkbox($model::optsStatus()) ?>
                 </div>
                 <?php if(\Yii::$app->controller->module->dateBasedAccessControl) { ?>
+
+                    <?php
+                        // sets $startday with the current date by timezone.
+                        // the timezone can be configured in the widgets module.
+                        // the default timezone is "UTC"
+                        $timezone = \Yii::$app->getModule('widgets')->timezone;
+                        $dateByTimeZone = new \DateTime(null, new \DateTimeZone($timezone));
+                        $dateByTimeZone->add(new DateInterval('PT5M')); // add 5 extra minutes
+                        $startDate = $dateByTimeZone->format('Y-m-d H:i');
+                    ?>
+
                 <div class="panel-heading">
                     <div class="row">
-                        <div class="form-group col-sm-2">
+                        <div class="form-group col-xs-12 col-md-6">
                             <?= $form->field($model, 'publish_at')->widget(DateTimePicker::class, [
                                 'options' => [
                                     'class' => 'form-control col-md-6',
@@ -152,22 +163,23 @@ JS;
                                     'autoclose' => true,
                                     'todayHighlight' => true,
                                     'minView' => (\Yii::$app->controller->module->datepickerMinutes) ? 0 : 1,
+                                    'startDate' => $startDate
                                 ],
                                 'clientEvents' => [],
-                            ])->textInput(['style' => 'color:white;']) ?>
+                            ])->textInput() ?>
                         </div>
-                        <div class="form-group col-sm-2">
+                        <div class="form-group col-xs-12 col-md-6">
                             <?= $form->field($model, 'expire_at')->widget(DateTimePicker::class, [
                                 'clientOptions' => [
                                     'format' => 'yyyy-mm-dd hh:ii',
                                     'autoclose' => true,
                                     'todayHighlight' => true,
                                     'minView' => (\Yii::$app->controller->module->datepickerMinutes) ? 0 : 1,
+                                    'startDate' => $startDate
                                 ],
                                 'clientEvents' => [],
-                            ])->textInput(['style' => 'color:white;']) ?>
+                            ])->textInput() ?>
                         </div>
-                        <?= $form->field($model, 'timezone')->hiddenInput()->label(false) ?>
                     </div>
                 </div>
                 <?php } ?>

--- a/src/widgets/Cell.php
+++ b/src/widgets/Cell.php
@@ -55,6 +55,13 @@ class Cell extends Widget
     public $moduleName = 'widgets';
 
     /**
+     * Timezone that will be used to correct dates.
+     *
+     * @var string
+     */
+    public $timezone;
+
+    /**
      * @inheritdoc
      */
     public function init()
@@ -62,6 +69,10 @@ class Cell extends Widget
         if (\Yii::$app->user->can('widgets_crud_widget', ['route' => true])) {
             \Yii::$app->trigger('registerMenuItems', new Event(['sender' => $this]));
             WidgetAsset::register(\Yii::$app->view);
+        }
+
+        if ($this->timezone === null) {
+            $this->timezone = \Yii::$app->getModule('widgets')->timezone;
         }
     }
 
@@ -307,13 +318,13 @@ class Cell extends Widget
                 (
                     !$widget->publish_at
                     ||
-                    new \DateTime() >= new \DateTime($widget->publish_at)
+                    new \DateTime(null, new \DateTimeZone($this->timezone)) >= new \DateTime($widget->publish_at, new \DateTimeZone($this->timezone))
                 )
                 &&
                 (
                     !$widget->expire_at
                     ||
-                    new \DateTime() <= new \DateTime($widget->expire_at)
+                    new \DateTime(null, new \DateTimeZone($this->timezone)) <= new \DateTime($widget->expire_at, new \DateTimeZone($this->timezone))
                 );
         }
 


### PR DESCRIPTION
timezone:
- removed timezone javascript hack and hidden input.
- Added timezone property to widgets module. Configurable in configs array. Default 'UTC'.
- Dates will be corrected by timezone before save.
- Cell widgets will display at corrected publish_at and hidden at corrected expire_at dates.
- added startDate to date picker with one minute offset in the future to prevent past dates picking.
- removed date picker styles that make dates invisible (white on white).
- updated date picker columns to prevent cropped dates.
- fixed not displayed error messages on update.
-updated README (cause the new module timezone property)