### PR TITLE
Translation meta

### DIFF
--- a/src/migrations/m180621_124412_add_translation_meta_table.php
+++ b/src/migrations/m180621_124412_add_translation_meta_table.php
@@ -1,0 +1,78 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m180621_124412_add_translation_meta_table
+ */
+class m180621_124412_add_translation_meta_table extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->createTable('{{%hrzg_widget_content_translation_meta}}', [
+            'id' => $this->primaryKey(),
+            'widget_content_id' => $this->integer()->notNull(),
+            'language' => $this->char(7)->notNull(),
+            'status' => 'VARCHAR(32) NOT NULL',
+            'created_at' => $this->dateTime(),
+            'updated_at' => $this->dateTime(),
+        ], 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB');
+
+        $this->addForeignKey(
+            'fk_widget_widget_translation_meta_id',
+            '{{%hrzg_widget_content_translation_meta}}',
+            'widget_content_id',
+            '{{%hrzg_widget_content}}',
+            'id',
+            'CASCADE',
+            'CASCADE');
+
+
+        // select all contents to insert them into the translation table
+        $query = new \yii\db\Query();
+        $contents = $query->select([
+            'id',
+            'status',
+        ])->from('{{%hrzg_widget_content}}')->all();
+
+        foreach ($contents as $content) {
+            $this->insert('{{%hrzg_widget_content_translation_meta}}', [
+                'widget_content_id' => $content['id'],
+                'language' => 'en',
+                'status' => $content['status'],
+            ]);
+        }
+
+        $this->dropColumn('{{%hrzg_widget_content}}', 'status');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        $this->addColumn('{{%hrzg_widget_content}}', 'status',
+            'VARCHAR(32) NOT NULL AFTER id');
+
+        // select all content translations to insert them back into the content table
+        $query = new \yii\db\Query();
+        $contents = $query->select([
+            'widget_content_id',
+            'language',
+            'status'
+        ])->from('{{%hrzg_widget_content_translation_meta}}')->all();
+
+        foreach ($contents as $content) {
+            $this->update('{{%hrzg_widget_content}}', [
+                'status' => $content['status']
+            ],['id' => $content['widget_content_id']]);
+        }
+
+        $this->dropForeignKey('fk_widget_widget_translation_meta_id', '{{%hrzg_widget_content_translation_meta}}');
+        $this->dropTable('{{%hrzg_widget_content_translation_meta}}');
+    }
+
+}

--- a/src/models/crud/WidgetContent.php
+++ b/src/models/crud/WidgetContent.php
@@ -198,8 +198,8 @@ class WidgetContent extends BaseWidget
     public static function optsStatus()
     {
         return [
-            0 => \Yii::t('widgets', 'Offline'),
             1 => \Yii::t('widgets', 'Online'),
+            0 => \Yii::t('widgets', 'Offline'),
         ];
     }
 

--- a/src/models/crud/WidgetContentTranslationMeta.php
+++ b/src/models/crud/WidgetContentTranslationMeta.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @link http://www.diemeisterei.de/
+ * @copyright Copyright (c) 2018 diemeisterei GmbH, Stuttgart
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace hrzg\widget\models\crud;
+
+use hrzg\widget\models\crud\base\WidgetTranslationMeta;
+
+
+/**
+ * Class WidgetContentTranslation
+ * @package hrzg\widget\models\crud
+ * @author Carsten Brandt <mail@cebe.cc>
+ */
+class WidgetContentTranslationMeta extends WidgetTranslationMeta
+{
+
+}

--- a/src/models/crud/base/Widget.php
+++ b/src/models/crud/base/Widget.php
@@ -7,6 +7,7 @@ namespace hrzg\widget\models\crud\base;
 use dmstr\db\traits\ActiveRecordAccessTrait;
 use dosamigos\translateable\TranslateableBehavior;
 use hrzg\widget\models\crud\WidgetContentTranslation;
+use hrzg\widget\models\crud\WidgetContentTranslationMeta;
 use Yii;
 
 /**
@@ -47,8 +48,18 @@ abstract class Widget extends \yii\db\ActiveRecord
         $behaviors['translatable'] = [
             'class' => TranslateableBehavior::className(),
             'languageField' => 'language',
+            'skipSavingDuplicateTranslation' => true,
             'translationAttributes' => [
                 'default_properties_json'
+            ]
+        ];
+        $behaviors['translation_meta'] = [
+            'class' => TranslateableBehavior::className(),
+            'relation' => 'translationsMeta',
+            'languageField' => 'language',
+            'skipSavingDuplicateTranslation' => false,
+            'translationAttributes' => [
+                'status'
             ]
         ];
 
@@ -61,6 +72,14 @@ abstract class Widget extends \yii\db\ActiveRecord
     public function getTranslations()
     {
         return $this->hasMany(WidgetContentTranslation::className(), ['widget_content_id' => 'id']);
+    }
+
+    /**
+     * @return \yii\db\ActiveQuery
+     */
+    public function getTranslationsMeta()
+    {
+        return $this->hasMany(WidgetContentTranslationMeta::className(), ['widget_content_id' => 'id']);
     }
 
     /**

--- a/src/models/crud/base/WidgetTranslationMeta.php
+++ b/src/models/crud/base/WidgetTranslationMeta.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * @link http://www.diemeisterei.de/
+ * @copyright Copyright (c) 2018 diemeisterei GmbH, Stuttgart
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * --- VARIABLES ---
+ *
+ * @var $this \yii\web\View
+ * @var $dataProvider \yii\data\ArrayDataProvider
+ */
+
+namespace hrzg\widget\models\crud\base;
+
+use bedezign\yii2\audit\AuditTrailBehavior;
+use dmstr\db\traits\ActiveRecordAccessTrait;
+use hrzg\widget\models\crud\query\WidgetTranslationMetaQuery;
+use hrzg\widget\models\crud\query\WidgetTranslationQuery;
+use hrzg\widget\models\crud\WidgetContent;
+use Yii;
+use yii\behaviors\TimestampBehavior;
+use yii\db\Expression;
+
+/**
+ * This is the base-model class for table "hrzg_widget_content_translation_meta".
+ *
+ * Class WidgetContentTranslationMeta
+ * @package hrzg\widget\models\crud
+ * @author Carsten Brandt <mail@cebe.cc>
+ *
+ * @property integer $id
+ * @property string $language
+ * @property integer $widget_content_id
+ * @property string $status
+ * @property string $created_at
+ * @property string $updated_at
+ */
+abstract class WidgetTranslationMeta extends \yii\db\ActiveRecord
+{
+    /**
+     * Alias name of table for crud viewsLists all Area models.
+     * Change the alias name manual if needed later.
+     *
+     * @return string
+     */
+    public function getAliasModel($plural = false)
+    {
+        if ($plural) {
+            return Yii::t('widgets', 'Widget Metadata Translations');
+        } else {
+            return Yii::t('widgets', 'Widget Metadata Translation');
+        }
+    }
+
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+
+        $behaviors['timestamp'] = [
+            'class' => TimestampBehavior::class,
+            'value' => new Expression('NOW()'),
+        ];
+
+        $behaviors['audit'] = [
+            'class' => AuditTrailBehavior::class
+        ];
+
+        return $behaviors;
+    }
+
+    /**
+     * @return string
+     */
+    public static function tableName()
+    {
+        return '{{%hrzg_widget_content_translation_meta}}';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rules()
+    {
+        return [
+            [['widget_content_id'], 'integer'],
+            [['language'], 'required'],
+            [['status'], 'string', 'max' => 32],
+            [
+                ['widget_content_id'],
+                'exist',
+                'skipOnError' => true,
+                'targetClass' => WidgetContent::class,
+                'targetAttribute' => ['widget_content_id' => 'id']
+            ]
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributeLabels()
+    {
+        return [
+            'id' => Yii::t('widgets', 'ID'),
+            'widget_content_id' => Yii::t('widgets', 'Content'),
+            'status' => Yii::t('widgets', 'Status'),
+            'created_at' => Yii::t('widgets', 'Created At'),
+            'updated_at' => Yii::t('widgets', 'Updated At'),
+        ];
+    }
+
+    /**
+     * @return \yii\db\ActiveQuery
+     */
+    public function getWidgetContent()
+    {
+        return $this->hasOne(WidgetContent::class, ['id' => 'widget_content_id']);
+    }
+
+    /**
+     * @inheritdoc
+     * @return \app\modules\crud\models\query\EventTranslationQuery the active query used by this AR class.
+     */
+    public static function find()
+    {
+        return new WidgetTranslationMetaQuery(get_called_class());
+    }
+}

--- a/src/models/crud/query/WidgetTranslationMetaQuery.php
+++ b/src/models/crud/query/WidgetTranslationMetaQuery.php
@@ -3,11 +3,11 @@
 namespace hrzg\widget\models\crud\query;
 
 /**
- * Class WidgetContentTranslationQuery
+ * Class WidgetContentTranslationMetaQuery
  * @package hrzg\widget\models\crud
- * @author Elias Luhr <e.luhr@herzogkommunikation.de>
+ * @author Carsten Brandt <mail@cebe.cc>
  */
-class WidgetTranslationQuery extends \yii\db\ActiveQuery
+class WidgetTranslationMetaQuery extends \yii\db\ActiveQuery
 {
 
     public function all($db = null)

--- a/src/models/crud/search/WidgetContent.php
+++ b/src/models/crud/search/WidgetContent.php
@@ -83,6 +83,8 @@ class WidgetContent extends WidgetModel
                 }
             ]
         );
+        // join for status field
+        $query->joinWith('translationsMeta');
 
         $this->load($params);
 

--- a/src/views/crud/widget/_form.php
+++ b/src/views/crud/widget/_form.php
@@ -12,6 +12,15 @@ use yii\bootstrap\Collapse;
 use zhuravljov\yii\widgets\DateTimePicker;
 
 $userAuthItems = $model::getUsersAuthItems();
+
+// enable bootstrap tooltips
+$this->registerJs(<<<JS
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+JS
+);
+
 ?>
 
 <div class="widget-form">
@@ -136,7 +145,14 @@ JS;
             <?= $form->errorSummary($model) ?>
             <div class="panel panel-<?= $model->status ? 'success' : 'warning' ?>">
                 <div class="panel-heading">
-                    <?= $form->field($model, 'status')->dropDownList($model::optsStatus()) ?>
+                    <?= $form->field($model, 'status')
+                        ->dropDownList($model::optsStatus())
+                        ->label($model->getAttributeLabel('status')
+                            . ($model->getBehavior('translation_meta')->isFallbackTranslation ?
+                               ' <span class="label label-warning" title="' . \Yii::t('widgets', 'Uses the same value as the fallback language. Saving this widget will override the default.') . '" data-toggle="tooltip" data-placement="top">fallback</span>'
+                               : '')
+                        );
+                    ?>
                 </div>
                 <?php if(\Yii::$app->controller->module->dateBasedAccessControl) { ?>
 

--- a/src/views/crud/widget/_form.php
+++ b/src/views/crud/widget/_form.php
@@ -136,7 +136,7 @@ JS;
             <?= $form->errorSummary($model) ?>
             <div class="panel panel-<?= $model->status ? 'success' : 'warning' ?>">
                 <div class="panel-heading">
-                    <?= $form->field($model, 'status')->checkbox($model::optsStatus()) ?>
+                    <?= $form->field($model, 'status')->dropDownList($model::optsStatus()) ?>
                 </div>
                 <?php if(\Yii::$app->controller->module->dateBasedAccessControl) { ?>
 

--- a/src/views/crud/widget/update.php
+++ b/src/views/crud/widget/update.php
@@ -50,6 +50,11 @@ $this->params['breadcrumbs'][] = \Yii::t('widgets', 'Edit');
 </div>
 <?php $this->endBlock() ?>
 
+<?php if ($model->getBehavior('translatable')->isFallbackTranslation) {
+    echo ' <div class="alert alert-info">' . \Yii::t('widgets', 'The currently displayed values are taken from the fallback language. If you change translated values a new translation will be stored for this widget. Changing the status does not affect the translation.') . '</div>';
+}
+?>
+
 <div class="giiant-crud widget-update">
     <?php $form = ActiveForm::begin(
         [

--- a/src/views/crud/widget/view.php
+++ b/src/views/crud/widget/view.php
@@ -20,6 +20,15 @@ $this->title = $model->getAliasModel() . ' ' . $model->id;
 $this->params['breadcrumbs'][] = ['label' => $model->getAliasModel(true), 'url' => ['index']];
 $this->params['breadcrumbs'][] = ['label' => (string)$model->id, 'url' => ['view', 'id' => $model->id]];
 $this->params['breadcrumbs'][] = \Yii::t('widgets', 'View');
+
+// enable bootstrap tooltips
+$this->registerJs(<<<JS
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+JS
+);
+
 ?>
 
 <?php $this->beginBlock('crud-navigation') ?>
@@ -84,7 +93,10 @@ $this->params['breadcrumbs'][] = \Yii::t('widgets', 'View');
             [
                 'attribute' => 'status',
                 'format' => 'raw',
-                'value' => $model::optsStatus()[$model->status]
+                'value' => Html::encode($model::optsStatus()[$model->status])
+                    . ($model->getBehavior('translation_meta')->isFallbackTranslation ?
+                        ' <span class="label label-warning" title="' . \Yii::t('widgets', 'Uses the same value as the fallback language. Edit and save to override the default.') . '" data-toggle="tooltip" data-placement="top">fallback</span>'
+                        : ''),
             ],
             [
                 'attribute' => 'widget_template_id',

--- a/src/widgets/Cell.php
+++ b/src/widgets/Cell.php
@@ -319,7 +319,7 @@ class Cell extends Widget
         $html .= '<span class="pull-left label '.
             ($widget->access_domain == '*' ? 'label-info' : 'label-default').'">'.
             FA::icon(FA::_GLOBE).' '.$widget->access_domain.
-            ($widget->isFallbackTranslation ? 'FALLBACK' : '').
+            ($widget->getBehavior('translatable')->isFallbackTranslation ? 'FALLBACK' : '').
             '</span>';
 
         $html .= Html::a(


### PR DESCRIPTION
- Make widget status "translateable", status now depends on the language
- show notification about fallbacks in the UI 

Note that status for existing data is only duplicated for `en`, so only for languages that have a fallback path that leads to `en` this will not affect existing data. For other languages (that do not fall back to `en`) the status will return empty which means widget is disabled.