### PR TITLE
allow ajax $ref in JsonEditor schema

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -68,6 +68,13 @@ class Module extends \yii\base\Module
     ];
 
     /**
+     * set ajax option for JsonEditor
+     *
+     * @var bool
+     */
+    public $allowAjaxInSchema = false;
+
+    /**
      * @param \yii\base\Action $action
      *
      * @return bool

--- a/src/views/crud/widget/_form.php
+++ b/src/views/crud/widget/_form.php
@@ -122,6 +122,7 @@ JS;
                         "no_additional_properties" => false,
                         'keep_oneof_values' => false,
                         'expand_height' => true,
+                        'ajax' => !empty(\Yii::$app->controller->module->allowAjaxInSchema) ? true : false,
                     ],
                 ]); ?>
             <?php \yii\widgets\Pjax::end() ?>


### PR DESCRIPTION
To be able to load external $ref URLs via ajax inside JsonEditor schema we must set the ajax option to true.

This PR add a new module property allowAjaxInSchema which can be used to enable this JsonEditor feature in widgets2-module.

see: https://github.com/json-editor/json-editor#ref-and-definitions