### PR TITLE
Serverside jason schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ Config
 		'playgroundLayout' => '@frontend/views/layouts/main',
 		'dateBasedAccessControl' => true,
 		'datepickerMinutes' => false,
-		'timezone' => 'Europe/Berlin'
+		'timezone' => 'Europe/Berlin',
+		// set ajax option for JsonEditor
+		'allowAjaxInSchema' => false,
+        // If true, the json content properties will be validated against the json schema from the widget_template.
+        // To be BC the default is false, but you should enable it
+		'validateContentSchema' => false
 	]
 ]
 ...

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "scrivo/highlight.php": "~8.0 || ~9.0",
     "zhuravljov/yii2-datetime-widgets" : "^1.1.0",
     "dmstr/yii2-ajax-button": "^1.0",
-    "trntv/yii2-aceeditor": "^2.1.0"
+    "trntv/yii2-aceeditor": "^2.1.0",
+    "justinrainbow/json-schema": "^5.2.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Module.php
+++ b/src/Module.php
@@ -74,6 +74,15 @@ class Module extends \yii\base\Module
      */
     public $allowAjaxInSchema = false;
 
+
+    /**
+     * If true, the json content properties will be validated against the json schema from the widget_template.
+     * To be BC the default is false, but you should enable it
+     *
+     * @var bool
+     */
+    public $validateContentSchema = false;
+
     /**
      * @param \yii\base\Action $action
      *

--- a/src/views/crud/widget-translation/_form.php
+++ b/src/views/crud/widget-translation/_form.php
@@ -4,6 +4,7 @@
  * @var $model \hrzg\widget\models\crud\WidgetContentTranslation
  * @var $form \yii\widgets\ActiveForm
  * @var array $userAuthItems
+ * @var object $schema
  */
 
 use hrzg\widget\Module;
@@ -89,7 +90,7 @@ $userAuthItems = $model::getUsersAuthItems();
 
     <div class="row">
         <div class="col-md-9">
-
+            <?= $form->errorSummary($model) ?>
 
             <?php \yii\widgets\Pjax::begin(['id' => 'pjax-widget-form']) ?>
             <?= $form->field($model, 'default_properties_json')->label(false)

--- a/src/views/crud/widget/_form.php
+++ b/src/views/crud/widget/_form.php
@@ -4,6 +4,7 @@
  * @var $model \hrzg\widget\models\crud\WidgetContent
  * @var $form \yii\widgets\ActiveForm
  * @var array $userAuthItems
+ * @var object $schema
  */
 
 use hrzg\widget\Module;


### PR DESCRIPTION
- New validateContentSchema module property.
- If true, the json content properties will be validated against the json schema from the widget_template.
- To be BC the default is false.
