### PR TITLE
add $route param to Cell Widget

### DIFF
--- a/src/widgets/Cell.php
+++ b/src/widgets/Cell.php
@@ -57,6 +57,16 @@ class Cell extends Widget implements ContextMenuItemsInterface
      */
     public $requestParam = 'pageId';
 
+    /**
+     * if set this route will be used as default for new widgets and appended in the
+     * list of routes in the query constraint
+     *
+     * if not set, the module/controller/action route from current context
+     * is used as default route
+     *
+     * @var
+     */
+    public $route;
 
     public $showWidgetControls = true;
     public $showContainerControls = true;
@@ -111,7 +121,7 @@ class Cell extends Widget implements ContextMenuItemsInterface
      */
     public function run()
     {
-        Url::remember('', $this->getRoute());
+        Url::remember('', $this->getActionRoute());
         return $this->renderWidgets();
     }
 
@@ -132,7 +142,7 @@ class Cell extends Widget implements ContextMenuItemsInterface
                     'url' => [
                         '/' . $this->moduleName . '/crud/widget/create',
                         'WidgetContent' => [
-                            'route' => $this->getRoute(),
+                            'route' => $this->getDefaultRoute(),
                             'container_id' => $this->id,
                             'request_param' => \Yii::$app->request->get($this->requestParam),
                         ],
@@ -146,7 +156,7 @@ class Cell extends Widget implements ContextMenuItemsInterface
                         'url' => [
                             '/' . $this->moduleName . '/crud/widget/index',
                             'WidgetContent' => [
-                                'route' => $this->getRoute(),
+                                'route' => $this->getDefaultRoute(),
                                 'container_id' => $this->id,
                                 'request_param' => \Yii::$app->request->get('id'),
                                 'access_domain' => \Yii::$app->language,
@@ -186,7 +196,7 @@ class Cell extends Widget implements ContextMenuItemsInterface
             ->andWhere(
                 [
                     'container_id' => $this->id,
-                    'route' => [$this->getRoute(), $this->getControllerRoute(), $this->getModuleRoute(), self::GLOBAL_ROUTE],
+                    'route' => array_filter([$this->route, $this->getActionRoute(), $this->getControllerRoute(), $this->getModuleRoute(), self::GLOBAL_ROUTE]),
                     '{{%hrzg_widget_content}}.access_domain' => [mb_strtolower(\Yii::$app->language), WidgetContent::$_all],
                 ]);
         if (\Yii::$app->user->can($this->rbacEditRole, ['route' => true])) {
@@ -204,10 +214,15 @@ class Cell extends Widget implements ContextMenuItemsInterface
         return $data;
     }
 
+    protected function getDefaultRoute()
+    {
+        return $this->route ? $this->route : $this->getActionRoute();
+    }
+
     /**
      * @return string
      */
-    private function getRoute()
+    private function getActionRoute()
     {
         #return '/' . \Yii::$app->controller->getRoute();
         return $this->getControllerRoute() . \Yii::$app->controller->action->id;
@@ -294,7 +309,7 @@ class Cell extends Widget implements ContextMenuItemsInterface
                 'url' => [
                     '/' . $this->moduleName . '/crud/widget/create',
                     'WidgetContent' => [
-                        'route' => $this->getRoute(),
+                        'route' => $this->getDefaultRoute(),
                         'container_id' => $this->id,
                         'request_param' => \Yii::$app->request->get($this->requestParam),
                         'widget_template_id' => $template->id,


### PR DESCRIPTION
Tis PR add `$route` param to Cell Widget, which can be used to prefill route attribute for new widget-content.

Use-Case:
currently, the route attribute for new widget-contents, created via links from cellControlls is the `module/controller/action` route of current context.

If one has e.g. a controller `frontend/products`  with actions `detail', `archive` and `preview` and cell content should be displayed in all actions, editor must change prefilled `route` for every new widget-content (error-prone).

With the new param the cell can be defined as:
```
    <?= Cell::widget(['id' => 'product_global', 'route' => 'frontend/product']) ?>
```

if route param is not set, `module/controller/action` route is used as before this change (BC)