### PR TITLE
Restored CopyController to ensure back compatibility

### DIFF
--- a/src/commands/CopyController.php
+++ b/src/commands/CopyController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace hrzg\widget\commands;
+
+use yii\console\Controller;
+
+/**
+ * --- PROPERTIES ---
+ *
+ * @author Elias Luhr
+ * @deprecated
+ */
+class CopyController extends Controller
+{
+    /**
+     * @deprecated
+     * @return bool|int
+     */
+    public function actionIndex()
+    {
+        return $this->stderr('copy function has been removed');
+    }
+
+    /**
+     * @deprecated
+     * @return bool|int
+     */
+    public function actionLanguage()
+    {
+        return $this->stderr('copy function has been removed');
+    }
+}


### PR DESCRIPTION
Added a deprecated notice instead of deleting it until we publish a new major release