### PR TITLE
Export and import widget templates

### DIFF
--- a/src/controllers/crud/WidgetTemplateController.php
+++ b/src/controllers/crud/WidgetTemplateController.php
@@ -49,4 +49,15 @@ class WidgetTemplateController extends \hrzg\widget\controllers\crud\base\Widget
         }
         \Yii::$app->end();
     }
+
+    public function actionImport()
+    {
+        $this->view->title = \Yii::t('widgets','Import');
+        $this->view->params['breadcrumbs'][]= [
+            'label' => \Yii::t('widgets','Widget Templates'),
+            'url' => ['index']
+        ];
+        $this->view->params['breadcrumbs'][]= $this->view->title;
+        return $this->render('import');
+    }
 }

--- a/src/controllers/crud/WidgetTemplateController.php
+++ b/src/controllers/crud/WidgetTemplateController.php
@@ -4,8 +4,10 @@ namespace hrzg\widget\controllers\crud;
 
 use hrzg\widget\assets\WidgetAsset;
 use hrzg\widget\helpers\WidgetTemplateExport;
+use hrzg\widget\models\WidgetTemplateImport;
 use yii\web\HttpException;
 use yii\web\Response;
+use yii\web\UploadedFile;
 
 /**
  * Class WidgetTemplateController
@@ -52,12 +54,24 @@ class WidgetTemplateController extends \hrzg\widget\controllers\crud\base\Widget
 
     public function actionImport()
     {
+
+        $model = new WidgetTemplateImport();
+        if (\Yii::$app->request->isPost) {
+            $model->tarFiles = UploadedFile::getInstances($model, 'tarFiles');
+            if ($model->upload() && $model->extractFiles() && $model->import()) {
+                \Yii::$app->getSession()->addFlash('success', \Yii::t('widgets', 'Import was successful'));
+                return $this->refresh();
+            }
+        }
+
         $this->view->title = \Yii::t('widgets','Import');
         $this->view->params['breadcrumbs'][]= [
             'label' => \Yii::t('widgets','Widget Templates'),
             'url' => ['index']
         ];
         $this->view->params['breadcrumbs'][]= $this->view->title;
-        return $this->render('import');
+        return $this->render('import', [
+            'model' => $model
+        ]);
     }
 }

--- a/src/controllers/crud/WidgetTemplateController.php
+++ b/src/controllers/crud/WidgetTemplateController.php
@@ -3,11 +3,13 @@
 namespace hrzg\widget\controllers\crud;
 
 use hrzg\widget\assets\WidgetAsset;
-use hrzg\widget\models\crud\WidgetTemplate;
-use yii\helpers\Url;
+use hrzg\widget\helpers\WidgetTemplateExport;
+use yii\web\HttpException;
+use yii\web\Response;
 
 /**
  * Class WidgetTemplateController
+ *
  * @package hrzg\widget\controllers\crud
  * @author Christopher Stebe <c.stebe@herzogkommunikation.de>
  */
@@ -17,5 +19,34 @@ class WidgetTemplateController extends \hrzg\widget\controllers\crud\base\Widget
     {
         WidgetAsset::register($this->view);
         return parent::beforeAction($action);
+    }
+
+    /**
+     * Export given widget template
+     *
+     * @param string $id
+     * @return void
+     * @throws \yii\base\ErrorException
+     * @throws \yii\base\ExitException
+     * @throws \yii\web\HttpException
+     */
+    public function actionExport($id)
+    {
+        $model = $this->findModel($id);
+
+        $export = new WidgetTemplateExport([
+            'widgetTemplate' => $model
+        ]);
+
+        if ($export->generateTar() === false) {
+            throw new HttpException(500, \Yii::t('widgets', 'Error while exporting widget template'));
+        }
+
+        if (\Yii::$app->getResponse()->sendFile($export->getTarFilePath()) instanceof Response) {
+            unlink($export->getTarFilePath());
+        } else {
+            throw new HttpException(500, \Yii::t('widgets', 'Error while downloading widget template'));
+        }
+        \Yii::$app->end();
     }
 }

--- a/src/helpers/WidgetTemplateExport.php
+++ b/src/helpers/WidgetTemplateExport.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace hrzg\widget\helpers;
+
+use hrzg\widget\models\crud\base\WidgetTemplate;
+use yii\base\BaseObject;
+use yii\base\ErrorException;
+use yii\base\InvalidConfigException;
+use yii\helpers\FileHelper;
+use yii\helpers\Inflector;
+use yii\helpers\Json;
+
+/**
+ * --- PUBLIC PROPERTIES ---
+ *
+ * @property string $exportDirectory
+ * @property string $templateFilename
+ * @property string $schemaFilename
+ * @property-write  WidgetTemplate $widgetTemplate
+ * @property string $tarFileName
+ *
+ * --- MAGIC GETTERS ---
+ *
+ * @property-read string $tarFilePath
+ *
+ * @author Elias Luhr
+ */
+class WidgetTemplateExport extends BaseObject
+{
+    /**
+     * Export directory of the generated tar file
+     * If this is set with an alias, it will be automatically resolved later on
+     *
+     * @var string
+     */
+    public $exportDirectory = '@runtime/tmp/dmstr/widgets/templates';
+
+    /**
+     * Name of the file which is generated from the content of the attribute $twig_template from the widget template
+     * The name must contain the file extension
+     *
+     * @var string
+     */
+    public $templateFilename = 'template.twig';
+
+    /**
+     * Name of the file which is generated from the content of the attribute $json_schema from the widget template
+     * The name must not contain the file extension
+     *
+     * @var string
+     */
+    public $schemaFilename = 'schema.json';
+
+    /**
+     * Optional name for the tar file. If not set, the value of the $name attribute from the widget template is used.
+     * The name must contain the file extension
+     *
+     * @var string
+     */
+    public $tarFileName;
+
+    /**
+     * Instance of the to be exported widget template instance
+     *
+     * @var WidgetTemplate
+     */
+    protected $_widgetTemplate;
+
+    /**
+     * @return WidgetTemplate
+     */
+    protected function getWidgetTemplate(): WidgetTemplate
+    {
+        return $this->_widgetTemplate;
+    }
+
+    /**
+     * @param WidgetTemplate $widgetTemplate
+     */
+    public function setWidgetTemplate(WidgetTemplate $widgetTemplate): void
+    {
+        $this->_widgetTemplate = $widgetTemplate;
+    }
+
+    /**
+     * @return void
+     * @throws \yii\base\Exception if the export directory could not be created due to an php error
+     * @throws \yii\base\InvalidConfigException if either the export directory is not set or the export directory cannot
+     * be set due to permission errors or the widget template is configured incorrectly
+     */
+    public function init()
+    {
+        parent::init();
+
+        // Ensure that the export directory for the generated files is set
+        if (empty($this->exportDirectory)) {
+            throw new InvalidConfigException('$exportDirectory must be set');
+        }
+
+        // Check if instance of widget template is not a new record or a new instance
+        if ($this->widgetTemplate instanceof WidgetTemplate && $this->widgetTemplate->getIsNewRecord() === true) {
+            throw new InvalidConfigException('Widget template must be saved at least once');
+        }
+
+        // Set tar name to widget template name if not set
+        if (empty($this->tarFileName)) {
+            $this->tarFileName = Inflector::slug($this->getWidgetTemplate()->name) . '.tar';
+        }
+
+        // Make sure that if an alias is set, it is resolved correctly
+        $this->exportDirectory = \Yii::getAlias($this->exportDirectory);
+
+        // Create export directory if not exists
+        if (FileHelper::createDirectory($this->exportDirectory) === false) {
+            throw new InvalidConfigException("Error while creating directory at: $this->exportDirectory");
+        }
+    }
+
+    /**
+     * Absolute file path to the tar file
+     *
+     * @return string
+     */
+    public function getTarFilePath(): string
+    {
+        return $this->exportDirectory . DIRECTORY_SEPARATOR . $this->tarFileName;
+    }
+
+    /**
+     * Absolute file path to the template file
+     *
+     * @return string
+     */
+    protected function getTemplateFilePath(): string
+    {
+        return $this->exportDirectory . DIRECTORY_SEPARATOR . $this->templateFilename;
+    }
+
+    /**
+     * Absolute file path to the twig file
+     *
+     * @return string
+     */
+    protected function getSchemaFilePath(): string
+    {
+        return $this->exportDirectory . DIRECTORY_SEPARATOR . $this->schemaFilename;
+    }
+
+    /**
+     * Absolute file path to the meta file
+     *
+     * @return string
+     */
+    protected function getMetaFilePath(): string
+    {
+        return $this->exportDirectory . DIRECTORY_SEPARATOR . 'meta.json';
+    }
+
+    /**
+     * Generate a tar file with the following contents
+     *  - template file (twig): the content from the twig_template attribute of the given widget template
+     *  - schema file (json): the content from the twig_template attribute of the given widget template
+     *  - meta file (json): this contains some information about the export
+     *
+     * @return bool
+     * @throws \yii\base\ErrorException
+     */
+    public function generateTar(): bool
+    {
+        // Remove existing tar file
+        if (is_file($this->getTarFilePath()) && unlink($this->getTarFilePath()) === false) {
+            return false;
+        }
+
+        // Generate needed files
+        if ($this->generateTemplateFile() === false) {
+            throw new ErrorException('Error while creating template file');
+        }
+        if ($this->generateSchemaFile() === false) {
+            throw new ErrorException('Error while creating schema file');
+        }
+        if ($this->generateMetaFile() === false) {
+            throw new ErrorException('Error while creating schema file');
+        }
+
+        // Create the tar archive
+        $phar = new \PharData($this->getTarFilePath());
+        // Add generated files
+        $phar->addFile($this->getTemplateFilePath(), $this->templateFilename);
+        $phar->addFile($this->getSchemaFilePath(),$this->schemaFilename);
+        $phar->addFile($this->getMetaFilePath(), 'meta.json');
+
+        // Remove generated files
+        if (is_file($this->getTemplateFilePath()) && unlink($this->getTemplateFilePath()) === false) {
+            return false;
+        }
+        if (is_file($this->getSchemaFilePath()) && unlink($this->getSchemaFilePath()) === false) {
+            return false;
+        }
+        if (is_file($this->getMetaFilePath()) && unlink($this->getMetaFilePath()) === false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Generate a twig file based on the value of the widget template $twig_template property
+     *
+     * @return bool
+     */
+    protected function generateTemplateFile(): bool
+    {
+        return file_put_contents($this->getTemplateFilePath(), $this->widgetTemplate->twig_template) !== false;
+    }
+
+    /**
+     * Generate a json file based on the value of the widget template $json_schema property
+     *
+     * @return bool
+     */
+    protected function generateSchemaFile(): bool
+    {
+        return file_put_contents($this->getSchemaFilePath(), $this->widgetTemplate->json_schema) !== false;
+    }
+
+    /**
+     * Generate a json file based on the value of the widget template $json_schema property
+     *
+     * @return bool
+     */
+    protected function generateMetaFile(): bool
+    {
+        $data = [
+            'id' => $this->getWidgetTemplate()->id,
+            'name' => $this->getWidgetTemplate()->name,
+            'php_class' => $this->getWidgetTemplate()->php_class,
+            'created_at' => $this->getWidgetTemplate()->created_at,
+            'updated_at' => $this->getWidgetTemplate()->updated_at,
+            'exported_at' => date('Y-m-d H:i:s'),
+            'download_url' => \Yii::$app->getRequest()->getAbsoluteUrl()
+        ];
+        return file_put_contents($this->getMetaFilePath(), Json::encode($data)) !== false;
+    }
+
+}

--- a/src/helpers/WidgetTemplateExport.php
+++ b/src/helpers/WidgetTemplateExport.php
@@ -27,6 +27,10 @@ use yii\helpers\Json;
  */
 class WidgetTemplateExport extends BaseObject
 {
+    public const META_FILE = 'meta.json';
+    public const TEMPLATE_FILE = 'template.twig';
+    public const SCHEMA_FILE = 'schema.json';
+
     /**
      * Export directory of the generated tar file
      * If this is set with an alias, it will be automatically resolved later on
@@ -41,7 +45,7 @@ class WidgetTemplateExport extends BaseObject
      *
      * @var string
      */
-    public $templateFilename = 'template.twig';
+    public $templateFilename = self::TEMPLATE_FILE;
 
     /**
      * Name of the file which is generated from the content of the attribute $json_schema from the widget template
@@ -49,7 +53,7 @@ class WidgetTemplateExport extends BaseObject
      *
      * @var string
      */
-    public $schemaFilename = 'schema.json';
+    public $schemaFilename = self::SCHEMA_FILE;
 
     /**
      * Optional name for the tar file. If not set, the value of the $name attribute from the widget template is used.
@@ -86,7 +90,7 @@ class WidgetTemplateExport extends BaseObject
      * @return void
      * @throws \yii\base\Exception if the export directory could not be created due to an php error
      * @throws \yii\base\InvalidConfigException if either the export directory is not set or the export directory cannot
-     * be set due to permission errors or the widget template is configured incorrectly
+     * be created due to permission errors or the widget template is configured incorrectly
      */
     public function init()
     {
@@ -153,7 +157,7 @@ class WidgetTemplateExport extends BaseObject
      */
     protected function getMetaFilePath(): string
     {
-        return $this->exportDirectory . DIRECTORY_SEPARATOR . 'meta.json';
+        return $this->exportDirectory . DIRECTORY_SEPARATOR . self::META_FILE;
     }
 
     /**
@@ -187,8 +191,8 @@ class WidgetTemplateExport extends BaseObject
         $phar = new \PharData($this->getTarFilePath());
         // Add generated files
         $phar->addFile($this->getTemplateFilePath(), $this->templateFilename);
-        $phar->addFile($this->getSchemaFilePath(),$this->schemaFilename);
-        $phar->addFile($this->getMetaFilePath(), 'meta.json');
+        $phar->addFile($this->getSchemaFilePath(), $this->schemaFilename);
+        $phar->addFile($this->getMetaFilePath(), self::META_FILE);
 
         // Remove generated files
         if (is_file($this->getTemplateFilePath()) && unlink($this->getTemplateFilePath()) === false) {

--- a/src/models/WidgetTemplateImport.php
+++ b/src/models/WidgetTemplateImport.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace hrzg\widget\models;
+
+use hrzg\widget\helpers\WidgetTemplateExport;
+use hrzg\widget\models\crud\WidgetTemplate;
+use hrzg\widget\widgets\TwigTemplate;
+use yii\base\ErrorException;
+use yii\base\InvalidArgumentException;
+use yii\base\InvalidConfigException;
+use yii\base\Model;
+use yii\helpers\FileHelper;
+use yii\helpers\Inflector;
+use yii\helpers\Json;
+
+/**
+ * --- PROPERTIES ---
+ *
+ * @property \yii\web\UploadedFile[] $tarFiles
+ *
+ * @author Elias Luhr
+ */
+class WidgetTemplateImport extends Model
+{
+    /**
+     * @var \yii\web\UploadedFile[]
+     */
+    public $tarFiles;
+
+    protected $_fileInfos = [];
+
+    /**
+     * Import extract directory of the generated tar file
+     * If this is set with an alias, it will be automatically resolved later on
+     *
+     * @var string
+     */
+    public $importDirectory = '@runtime/tmp/dmstr/widgets/templates/import';
+
+    /**
+     * @return void
+     * @throws \yii\base\Exception if the export directory could not be created due to an php error
+     * @throws \yii\base\InvalidConfigException if either the import directory is not set or the export directory cannot
+     * be created due to permission errors
+     */
+    public function init()
+    {
+        parent::init();
+
+        // Ensure that the import directory for the generated files is set
+        if (empty($this->importDirectory)) {
+            throw new InvalidConfigException('$importDirectory must be set');
+        }
+
+        // Make sure that if an alias is set, it is resolved correctly
+        $this->importDirectory = \Yii::getAlias($this->importDirectory);
+
+        // recreate import directory
+        try {
+            FileHelper::removeDirectory($this->importDirectory);
+        } catch (ErrorException $e) {
+            \Yii::error($e->getMessage());
+            throw new InvalidConfigException("Error while recreating directory at: $this->importDirectory");
+        }
+        if (FileHelper::createDirectory($this->importDirectory) === false) {
+            throw new InvalidConfigException("Error while creating directory at: $this->importDirectory");
+        }
+    }
+
+    public function rules()
+    {
+        return [
+            ['tarFiles', 'file', 'skipOnEmpty' => false, 'extensions' => 'tar', 'maxFiles' => 20]
+        ];
+    }
+
+    public function upload(): bool
+    {
+        if ($this->validate()) {
+            foreach ($this->tarFiles as $file) {
+                if ($file->saveAs($this->importDirectory . DIRECTORY_SEPARATOR . $file->baseName . '.' . $file->extension) === false) {
+                    $this->addError('tarFiles', \Yii::t('widgets', 'Error while saving file'));
+                }
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    public function attributeLabels()
+    {
+        $attributeLabels = parent::attributeLabels();
+        $attributeLabels['tarFiles'] = \Yii::t('widgets', 'Files');
+        return $attributeLabels;
+    }
+
+    public function removeImportDirectory(): bool
+    {
+        try {
+            FileHelper::removeDirectory($this->importDirectory);
+            return true;
+        } catch (\ErrorException $e) {
+            \Yii::error($e->getMessage());
+            return false;
+        }
+    }
+
+    protected function extractTar(string $filepath, string $extractDirectory): bool
+    {
+        return (new \PharData($filepath))->extractTo($extractDirectory);
+    }
+
+    public function extractFiles(): bool
+    {
+        foreach ($this->tarFiles as $file) {
+            $filepath = $this->importDirectory . DIRECTORY_SEPARATOR . $file->baseName . '.' . $file->extension;
+            if ($this->extractTar($filepath, $this->extractDirectory($file->baseName)) === false) {
+                $this->addError('tarFiles', \Yii::t('widgets', 'Error while extracting file'));
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected function extractDirectory(string $filename): string
+    {
+        return $this->importDirectory . DIRECTORY_SEPARATOR . Inflector::slug(basename($filename));
+    }
+
+    public function import()
+    {
+        $transaction = WidgetTemplate::getDb()->beginTransaction();
+        if ($transaction && $transaction->getIsActive()) {
+            foreach ($this->tarFiles as $file) {
+                $extractDirectory = $this->extractDirectory($file->baseName);
+                if ($this->importTemplateByDirectory($extractDirectory) === false) {
+                    $this->addError('tarFiles', \Yii::t('widgets', 'Error while importing widget template'));
+                    $transaction->rollBack();
+                    return false;
+                }
+
+                FileHelper::removeDirectory($extractDirectory);
+            }
+            $transaction->commit();
+            return true;
+        }
+        return false;
+    }
+
+    protected function importTemplateByDirectory(string $extractDirectory): bool
+    {
+        $meta = $this->templateMeta($extractDirectory);
+        $template = $this->templateContent($extractDirectory);
+        $schema = $this->schemaContent($extractDirectory);
+
+        $model = new WidgetTemplate([
+            'name' => $meta['name'],
+            'php_class' => $meta['php_class'],
+            'twig_template' => $template,
+            'json_schema' => $schema
+        ]);
+
+        if ($model->save() === false) {
+            \Yii::error($model->getErrors());
+            return false;
+        }
+        return true;
+    }
+
+    protected function templateMeta(string $extractDirectory): array
+    {
+        $metaFilename = $extractDirectory . DIRECTORY_SEPARATOR . WidgetTemplateExport::META_FILE;
+        if (is_file($metaFilename)) {
+            $content = file_get_contents($metaFilename);
+            try {
+                $data = Json::decode($content);
+
+                return [
+                    'name' => $data['name'] ?? basename($extractDirectory),
+                    'php_class' => $data['php_class'] ?? TwigTemplate::class
+                ];
+            } catch (InvalidArgumentException $e) {
+                \Yii::error($e->getMessage());
+            }
+        }
+        return [
+            'name' => basename($extractDirectory),
+            'php_class' => TwigTemplate::class
+        ];
+    }
+
+    protected function templateContent(string $extractDirectory): string
+    {
+        $templateFilename = $extractDirectory . DIRECTORY_SEPARATOR . WidgetTemplateExport::TEMPLATE_FILE;
+        $fallbackTemplate = '{# not set #}';
+        if (is_file($templateFilename)) {
+            return file_get_contents($templateFilename) ?: $fallbackTemplate;
+        }
+
+        return $fallbackTemplate;
+    }
+
+    protected function schemaContent(string $extractDirectory): string
+    {
+        $schemaFilename = $extractDirectory . DIRECTORY_SEPARATOR . WidgetTemplateExport::SCHEMA_FILE;
+        $fallbackSchema = '{}';
+        if (is_file($schemaFilename)) {
+            return file_get_contents($schemaFilename) ?: $fallbackSchema;
+        }
+
+        return $fallbackSchema;
+    }
+}

--- a/src/views/crud/widget-template/import.php
+++ b/src/views/crud/widget-template/import.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * --- FROM CONTEXT ---
+ *
+ * @var yii\web\View $this
+ */
+
+use insolita\wgadminlte\Box;
+
+Box::begin()
+?>
+<h1>
+    <?php echo Yii::t('widgets', 'WidgetTemplates'); ?>
+    <small><?php echo $this->title; ?></small>
+</h1>
+<?php
+Box::end();

--- a/src/views/crud/widget-template/import.php
+++ b/src/views/crud/widget-template/import.php
@@ -3,9 +3,12 @@
  * --- FROM CONTEXT ---
  *
  * @var yii\web\View $this
+ * @var \hrzg\widget\models\WidgetTemplateImport $model
  */
 
 use insolita\wgadminlte\Box;
+use yii\helpers\Html;
+use yii\widgets\ActiveForm;
 
 Box::begin()
 ?>
@@ -13,5 +16,19 @@ Box::begin()
     <?php echo Yii::t('widgets', 'WidgetTemplates'); ?>
     <small><?php echo $this->title; ?></small>
 </h1>
+    <div class="row">
+        <div class="col-xs-12 col-md-4">
+            <?php
+            $form = ActiveForm::begin();
+            echo $form->field($model, 'tarFiles[]')->fileInput(['multiple' => true, 'accept' => 'application/x-tar','class' => 'form-control']);
+            ?>
+            <div class="form-group">
+                <?php echo Html::submitButton(Yii::t('widgets','Upload'),['class' => 'btn btn-primary']) ?>
+            </div>
+            <?php
+            ActiveForm::end();
+            ?>
+        </div>
+    </div>
 <?php
 Box::end();

--- a/src/views/crud/widget-template/index.php
+++ b/src/views/crud/widget-template/index.php
@@ -33,6 +33,10 @@ $this->params['breadcrumbs'][] = $this->title;
             <?= Html::a('<span class="glyphicon glyphicon-plus"></span> '.\Yii::t('widgets', 'New'), ['create'],
                 ['class' => 'btn btn-success']) ?>
         </div>
+        <div class="pull-right">
+            <?= Html::a('<span class="glyphicon glyphicon-import"></span> '.\Yii::t('widgets', 'Import'), ['import'],
+                ['class' => 'btn btn-info']) ?>
+        </div>
     </div>
     <hr/>
     <div class="table-responsive">

--- a/src/views/crud/widget-template/index.php
+++ b/src/views/crud/widget-template/index.php
@@ -53,7 +53,12 @@ $this->params['breadcrumbs'][] = $this->title;
             'columns' => [
                 [
                     'class' => 'yii\grid\ActionColumn',
-                    'template' => '{view} {update} {delete}',
+                    'template' => '{view} {update} {export} {delete}',
+                    'buttons' => [
+                            'export' => function ($url) {
+                                return Html::a('<span class="glyphicon glyphicon-export"></span>', $url,['data-pjax' => 0]);
+                            }
+                    ],
                     'urlCreator' => function ($action, $model, $key, $index) {
                         // using the column name as key, not mapping to 'id' like the standard generator
                         $params = is_array($key) ? $key : [$model->primaryKey()[0] => (string) $key];

--- a/src/views/crud/widget-template/index.php
+++ b/src/views/crud/widget-template/index.php
@@ -1,5 +1,4 @@
 <?php
-use hrzg\widget\models\crud\WidgetTemplate;
 use insolita\wgadminlte\Box;
 use yii\grid\GridView;
 use yii\helpers\Html;
@@ -33,10 +32,12 @@ $this->params['breadcrumbs'][] = $this->title;
             <?= Html::a('<span class="glyphicon glyphicon-plus"></span> '.\Yii::t('widgets', 'New'), ['create'],
                 ['class' => 'btn btn-success']) ?>
         </div>
+        <?php if (Yii::$app->getUser()->can('widgets_crud_widget-template_import')): ?>
         <div class="pull-right">
             <?= Html::a('<span class="glyphicon glyphicon-import"></span> '.\Yii::t('widgets', 'Import'), ['import'],
                 ['class' => 'btn btn-info']) ?>
         </div>
+        <?php endif ?>
     </div>
     <hr/>
     <div class="table-responsive">
@@ -67,6 +68,9 @@ $this->params['breadcrumbs'][] = $this->title;
                         return Url::toRoute($params);
                     },
                     'contentOptions' => ['nowrap' => 'nowrap'],
+                    'visibleButtons' => [
+                            'export' => Yii::$app->getUser()->can('widgets_crud_widget-template_export')
+                    ]
                 ],
                 'name',
                 'php_class',

--- a/src/views/crud/widget-template/view.php
+++ b/src/views/crud/widget-template/view.php
@@ -28,11 +28,15 @@ $this->params['breadcrumbs'][] = Yii::t('widgets', 'View');
             ['update', 'id' => $model->id],
             ['class' => 'btn btn-info']
         ) ?>
-        <?= Html::a(
-            '<span class="glyphicon glyphicon-download"></span> ' . Yii::t('widgets', 'Export'),
-            ['export', 'id' => $model->id],
-            ['class' => 'btn btn-warning']
-        ) ?>
+        <?php
+        if (Yii::$app->getUser()->can('widgets_crud_widget-template_export')) {
+            echo Html::a(
+                '<span class="glyphicon glyphicon-download"></span> ' . Yii::t('widgets', 'Export'),
+                ['export', 'id' => $model->id],
+                ['class' => 'btn btn-warning']
+            );
+        }
+        ?>
         <?= Html::a(
             '<span class="glyphicon glyphicon-trash"></span> ' . Yii::t('widgets', 'Delete'),
             ['delete', 'id' => $model->id],

--- a/src/views/crud/widget-template/view.php
+++ b/src/views/crud/widget-template/view.php
@@ -29,6 +29,11 @@ $this->params['breadcrumbs'][] = Yii::t('widgets', 'View');
             ['class' => 'btn btn-info']
         ) ?>
         <?= Html::a(
+            '<span class="glyphicon glyphicon-download"></span> ' . Yii::t('widgets', 'Export'),
+            ['export', 'id' => $model->id],
+            ['class' => 'btn btn-warning']
+        ) ?>
+        <?= Html::a(
             '<span class="glyphicon glyphicon-trash"></span> ' . Yii::t('widgets', 'Delete'),
             ['delete', 'id' => $model->id],
             [

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -129,6 +129,11 @@ $moduleId = $this->context->module->id;
                 <?php
             }
         } ?>
+        <?= Html::a(
+            FA::icon(FA::_UPLOAD) . ' ' . \Yii::t('widgets', 'Import'),
+            ['crud/widget-template/import'],
+            ['class' => 'btn btn-app']);
+        ?>
     </div>
 </div>
 <?php Box::end() ?>

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -129,10 +129,12 @@ $moduleId = $this->context->module->id;
                 <?php
             }
         } ?>
-        <?= Html::a(
-            FA::icon(FA::_UPLOAD) . ' ' . \Yii::t('widgets', 'Import'),
-            ['crud/widget-template/import'],
-            ['class' => 'btn btn-app']);
+        <?php
+        if (Yii::$app->getUser()->can('widgets_crud_widget-template_import')) {
+            echo Html::a(FA::icon(FA::_UPLOAD) . ' ' . \Yii::t('widgets', 'Import'),
+                ['crud/widget-template/import'],
+                ['class' => 'btn btn-app']);
+        }
         ?>
     </div>
 </div>


### PR DESCRIPTION
## Export and import widget templates

This PR provides an export and import functionality for the existing widget template CRUD

### Export

Exporting a widget can be done via the newly added export buttons either on the widget template overview page or the widget templates detail page

When exporting a widget template a `.tar` file will be created to summarize the following three files:

1. meta.json -  Optional for the import. If not present a fallback for the name and php_class column will be used
2. schema.json - This contains the json schema for the widget
3. template.twig - This contains the twig template for the widget

### Import

To import a generated `.tar` file to the db you can do this either from the widget overview (/widget/default/index) page or the widget template overview page. You can either upload one or up to 20 `.tar` files (we can still discuss this value. But more makes no sense in my opinion)

For each functionality a new permission check was added:

- import: widgets_crud_widget-template_import
- export: widgets_crud_widget-template_export

Only if these permissions are granted to the user, the user will be able to see the links and access the corresponding pages.

<img width="1901" alt="widget-template-general-overview" src="https://user-images.githubusercontent.com/13000805/165084276-6db4a322-660e-4fe0-aaa7-86312ea14832.png">
<img width="962" alt="widget-template-view" src="https://user-images.githubusercontent.com/13000805/165084286-12e0200a-3adc-41a4-8b79-a683a89c91c2.png">
<img width="961" alt="widget-template-overview" src="https://user-images.githubusercontent.com/13000805/165084288-676f8e56-9c51-4052-8483-da8b244f3742.png">


