### PR TITLE
Allow frontend editing for widgets

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -79,6 +79,13 @@ class Module extends \yii\base\Module
     public $validateContentSchema = false;
 
     /**
+     * If true, this options allows the user to edit content directly
+     *
+     * @var bool
+     */
+    public $enableFrontendEditing = false;
+
+    /**
      * @param \yii\base\Action $action
      *
      * @return bool


### PR DESCRIPTION
With this feature I introduced a new property that enables/disables frontend editing. To ensure backward compatibility, the new feature is disabled by default. Working example see video:

https://user-images.githubusercontent.com/13000805/170959303-2d865834-2c3f-4a7d-89b8-1d10aea10132.mov