### PR TITLE
Feature/improve widgets UI

### DIFF
--- a/src/views/crud/widget/_form.php
+++ b/src/views/crud/widget/_form.php
@@ -120,6 +120,7 @@ JS;
                     'schema' => $schema,
                     'clientOptions' => [
                         'theme' => 'bootstrap3',
+                        'iconlib' => 'fontawesome4',
                         'disable_collapse' => true,
                         'disable_properties' => false,
                         "no_additional_properties" => false,

--- a/src/widgets/Cell.php
+++ b/src/widgets/Cell.php
@@ -402,6 +402,7 @@ JS
             'params' => ['status' => $newStatus],
             'options' => [
                 'class' => 'btn  btn-widget-control btn-' . (($widget->status && $published) ? 'success' : 'warning'),
+                'aria-label' => 'loading',
                 'data' => [
                     'button' => 'loading',
                     'loading-text' => FA::icon(FA::_SPINNER,['class' => 'fa-spin']),
@@ -420,6 +421,7 @@ JS
                 ['/' . $this->moduleName . '/crud/widget-translation/delete', 'id' => $widget->getTranslation()->id],
                 [
                     'class' => 'btn  btn-widget-control btn-danger',
+                    'aria-label' => 'delete',
                     'data' => [
                         'method' => 'delete',
                         'confirm' => \Yii::t('widgets', 'Are you sure to delete this translation?'),
@@ -438,6 +440,7 @@ JS
                     ['/' . $this->moduleName . '/crud/widget/delete', 'id' => $widget->id],
                     [
                         'class' => 'btn  btn-widget-control btn-danger',
+                        'aria-label' => 'delete',
                         'data' => [
                             'method' => 'delete',
                             'confirm' => \Yii::t('widgets', 'Are you sure to delete this translation?'),
@@ -457,6 +460,7 @@ JS
             ['/' . $this->moduleName . '/crud/widget/update', 'id' => $widget->id],
             [
                 'class' => 'btn  btn-widget-control btn-primary',
+                'aria-label' => 'update',
                 'target' => \Yii::$app->params['backend.iframe.name'] ?? '_self'
             ]
         );
@@ -477,6 +481,7 @@ JS
             ['/' . $this->moduleName . '/crud/widget/view', 'id' => $widget->id],
             [
                 'class' => 'btn  btn-widget-control btn-' . $color,
+                'aria-label' => 'view',
                 'target' => \Yii::$app->params['backend.iframe.name'] ?? '_self'
             ]
         );

--- a/src/widgets/Cell.php
+++ b/src/widgets/Cell.php
@@ -402,7 +402,7 @@ JS
             'params' => ['status' => $newStatus],
             'options' => [
                 'class' => 'btn  btn-widget-control btn-' . (($widget->status && $published) ? 'success' : 'warning'),
-                'aria-label' => 'loading',
+                'aria-label' => \Yii::t('widgets', 'Toggle visibility status'),
                 'data' => [
                     'button' => 'loading',
                     'loading-text' => FA::icon(FA::_SPINNER,['class' => 'fa-spin']),
@@ -421,7 +421,7 @@ JS
                 ['/' . $this->moduleName . '/crud/widget-translation/delete', 'id' => $widget->getTranslation()->id],
                 [
                     'class' => 'btn  btn-widget-control btn-danger',
-                    'aria-label' => 'delete',
+                    'aria-label' => \Yii::t('widgets', 'Delete translation'),
                     'data' => [
                         'method' => 'delete',
                         'confirm' => \Yii::t('widgets', 'Are you sure to delete this translation?'),
@@ -440,7 +440,7 @@ JS
                     ['/' . $this->moduleName . '/crud/widget/delete', 'id' => $widget->id],
                     [
                         'class' => 'btn  btn-widget-control btn-danger',
-                        'aria-label' => 'delete',
+                        'aria-label' => \Yii::t('widgets', 'Delete Widget'),
                         'data' => [
                             'method' => 'delete',
                             'confirm' => \Yii::t('widgets', 'Are you sure to delete this translation?'),
@@ -460,7 +460,7 @@ JS
             ['/' . $this->moduleName . '/crud/widget/update', 'id' => $widget->id],
             [
                 'class' => 'btn  btn-widget-control btn-primary',
-                'aria-label' => 'update',
+                'aria-label' => \Yii::t('widgets', 'Update Widget'),
                 'target' => \Yii::$app->params['backend.iframe.name'] ?? '_self'
             ]
         );
@@ -481,7 +481,7 @@ JS
             ['/' . $this->moduleName . '/crud/widget/view', 'id' => $widget->id],
             [
                 'class' => 'btn  btn-widget-control btn-' . $color,
-                'aria-label' => 'view',
+                'aria-label' => \Yii::t('widgets', 'View Widget'),
                 'target' => \Yii::$app->params['backend.iframe.name'] ?? '_self'
             ]
         );


### PR DESCRIPTION
Added `'iconlib' => 'fontawesome4'` To JSONEditorWidget: Specially useful when working with objects that should start collapsed and arrays. Is also language agnostic.

Without iconlib:

<img width="1004" alt="without-icons" src="https://user-images.githubusercontent.com/13135260/180436547-5d1cc7af-1b13-43e9-ba6b-404bd34eefdd.png">

With iconlib:

<img width="1003" alt="with-icons" src="https://user-images.githubusercontent.com/13135260/180436569-64a162da-7bb6-4359-a0b0-59cc76832538.png">

Added aria-labels to Cell buttons: I use tools to check Accessibility and SEO. For each widget in the page 4 extra errors are always displayed in addition to those ones that should bi fixed. It's clear that this brings nothing to the end user (cell are hidden) but for development It is much easy to debug the real errors when logged and the page is cleared from bloating errors markers and warnings.

Without aria labels:

<img width="1056" alt="without-aria-labels" src="https://user-images.githubusercontent.com/13135260/180436606-b5b3b914-eeea-42db-917c-4c11ad22f997.png">

With aria labels:

<img width="1053" alt="with-aria-labels" src="https://user-images.githubusercontent.com/13135260/180436623-208947d3-283f-4d43-98e9-494bbee75407.png">

