### PR TITLE
Fixing module instance bug

### DIFF
--- a/src/models/crud/WidgetContent.php
+++ b/src/models/crud/WidgetContent.php
@@ -3,7 +3,6 @@
 namespace hrzg\widget\models\crud;
 
 use hrzg\widget\models\crud\base\Widget as BaseWidget;
-use hrzg\widget\Module;
 use hrzg\widget\widgets\Cell;
 use JsonSchema\Validator;
 use yii\behaviors\TimestampBehavior;
@@ -35,6 +34,11 @@ class WidgetContent extends BaseWidget
     public $timezone;
 
     /**
+     * @var string
+     */
+    public $module = 'widgets';
+
+    /**
      * @inheritdoc
      * @return array
      */
@@ -59,7 +63,7 @@ class WidgetContent extends BaseWidget
         parent::init();
 
         if ($this->timezone === null) {
-            $this->timezone = Module::getInstance()->timezone;
+            $this->timezone = \Yii::$app->getModule('widgets')->timezone;
         }
     }
 

--- a/src/models/crud/WidgetContent.php
+++ b/src/models/crud/WidgetContent.php
@@ -63,7 +63,7 @@ class WidgetContent extends BaseWidget
         parent::init();
 
         if ($this->timezone === null) {
-            $this->timezone = \Yii::$app->getModule('widgets')->timezone;
+            $this->timezone = \Yii::$app->getModule($this->module)->timezone;
         }
     }
 


### PR DESCRIPTION
The WidgetContent currently sets the timezone in its `init` method by getting the timezone set in the module via `Module::getInstance()->timezone`. But this only works if the (widgets) Module is loaded in the current context. When using the model outside of the module this results in an error. 

This bugfix allows to use the model where you want and allows the change the module id if needed via dependency injection.