### PR TITLE
allow varchar 255 for access_owner as in other access_ cols

### DIFF
--- a/src/migrations/m230606_120120_change_access_owner_col_format.php
+++ b/src/migrations/m230606_120120_change_access_owner_col_format.php
@@ -1,0 +1,18 @@
+<?php
+
+use yii\db\Migration;
+
+class m230606_120120_change_access_owner_col_format extends Migration
+{
+    public function up()
+    {
+        // allow uuid and longer strings as access_owner value
+        $this->alterColumn("{{%hrzg_widget_content}}","access_owner", $this->string(255));
+        $this->alterColumn("{{%hrzg_widget_content_translation}}","access_owner", $this->string(255));
+    }
+
+    public function down()
+    {
+        return false;
+    }
+}

--- a/src/models/crud/base/Widget.php
+++ b/src/models/crud/base/Widget.php
@@ -132,7 +132,8 @@ abstract class Widget extends ActiveRecord
             [['container_id', 'route'], 'string', 'max' => 128],
             [['domain_id'], 'string', 'max' => 64],
             [['widget_template_id', 'copied_from'], 'integer'],
-            [['rank', 'access_owner'], 'string', 'max' => 11],
+            [['rank'], 'string', 'max' => 11],
+            [['access_owner'], 'string', 'max' => 255, 'strict' => false],
             [['request_param', 'access_read', 'access_update', 'access_delete'], 'string', 'max' => 255],
             [['access_domain'], 'string', 'max' => 8],
         ];

--- a/src/models/crud/base/WidgetTranslation.php
+++ b/src/models/crud/base/WidgetTranslation.php
@@ -93,7 +93,7 @@ abstract class WidgetTranslation extends \yii\db\ActiveRecord
             [['widget_content_id'], 'integer'],
             [['language'], 'required'],
             [['default_properties_json'], 'string'],
-            [['access_owner'], 'string', 'max' => 11],
+            [['access_owner'], 'string', 'max' => 255, 'strict' => false],
             [['access_read', 'access_update', 'access_delete'], 'string', 'max' => 255],
             [['access_domain'], 'string', 'max' => 8],
             [


### PR DESCRIPTION
Ths PR changes the access_owner attribute type from string(11) to string(255) to be able to store e.g. uuids
