### PR TITLE
str_pad needs a string as the first parameter

### DIFF
--- a/src/models/crud/WidgetContent.php
+++ b/src/models/crud/WidgetContent.php
@@ -129,7 +129,7 @@ class WidgetContent extends BaseWidget
         $rules['unique-default-rank'] = [
             'rank',
             'default',
-            'value' => 'a-' . str_pad(self::find()->max('id'), 4, '0', STR_PAD_LEFT) . '0'
+            'value' => 'a-' . str_pad(self::find()->max('id') ?: '0', 4, '0', STR_PAD_LEFT) . '0'
         ];
         $rules['unique-default-domain_id'] = [
             'domain_id',


### PR DESCRIPTION
When the list of widget content is completely empty, ->max('id') returns null which is not expected as the value of the first parameter of the str_pad function.