### PR TITLE
Invalid status & Single type schema

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -217,3 +217,16 @@ APP CLAUS WIDGET TEMPLATES (JSON)
 }
 
 ```
+
+*Single type schema*
+--------------------
+
+```json
+{
+  "type": "string"
+}
+```
+
+```twig
+{{ value }}
+```

--- a/src/models/crud/WidgetContent.php
+++ b/src/models/crud/WidgetContent.php
@@ -208,7 +208,11 @@ class WidgetContent extends BaseWidget
 
             ];
         }
-
+        $rules['default-status'] = [
+            'status',
+            'in',
+            'range' => array_keys(self::optsStatus())
+        ];
         return $rules;
     }
 

--- a/src/views/crud/widget/index.php
+++ b/src/views/crud/widget/index.php
@@ -150,7 +150,7 @@ $actionColumnTemplateString = '<div class="action-buttons">'.$actionColumnTempla
                     'contentOptions' => ['nowrap' => 'nowrap'],
                     'filter'=> \hrzg\widget\models\crud\WidgetContent::optsStatus(),
                     'value' => function($model) {
-                        return $model->status ? $model::optsStatus()[$model->status] : 'n/a';
+                        return $model::optsStatus()[$model->status] ?? 'n/a';
                     },
                     'filterInputOptions' => [
                         'class' => 'form-control',

--- a/src/views/crud/widget/view.php
+++ b/src/views/crud/widget/view.php
@@ -86,7 +86,7 @@ JS
             [
                 'attribute' => 'status',
                 'format' => 'raw',
-                'value' => (isset($model->status) ? Html::encode($model::optsStatus()[$model->status]) : 'n/a')
+                'value' => (Html::encode($model::optsStatus()[$model->status]) ?? 'n/a')
                     . ($model->getBehavior('translation_meta')->isFallbackTranslation ?
                         ' <span class="label label-warning" title="' . \Yii::t('widgets', 'Uses the same value as the fallback language. Edit and save to override the default.') . '" data-toggle="tooltip" data-placement="top">fallback</span>'
                         : ''),

--- a/src/widgets/Cell.php
+++ b/src/widgets/Cell.php
@@ -24,6 +24,7 @@ use yii\caching\TagDependency;
 use yii\helpers\Html;
 use yii\helpers\Json;
 use yii\helpers\Url;
+use yii\helpers\VarDumper;
 
 /**
  * Class Cell
@@ -268,6 +269,9 @@ class Cell extends Widget implements ContextMenuItemsInterface
             $class->setView($widget->getViewFile());
 
             if ($properties) {
+                if (is_string($properties)) {
+                    $properties = [$properties];
+                }
                 $class->setProperties($properties);
             }
             $visibility = $widget->isVisibleFrontend() ? '' : 'hrzg-widget-widget-invisible-frontend';

--- a/src/widgets/Cell.php
+++ b/src/widgets/Cell.php
@@ -268,8 +268,11 @@ class Cell extends Widget implements ContextMenuItemsInterface
             $class->setView($widget->getViewFile());
 
             if ($properties) {
-                if (is_string($properties)) {
-                    $properties = [$properties];
+                // $properties can only be type array, boolean, integer or float (!=0) or a string
+                // Cast $properties boolean, integer, float or string to an array
+                if (!is_array($properties)) {
+                    // If there is only one property, make it accessible as `value`
+                    $properties = ['value' => $properties];
                 }
                 $class->setProperties($properties);
             }
@@ -284,7 +287,7 @@ class Cell extends Widget implements ContextMenuItemsInterface
             }
             $published = $this->checkPublicationStatus($widget);
             if (\Yii::$app->user->can($this->rbacEditRole, ['route' => true]) || ($widget->status == 1 && $published == true)) {
-                $html .= Html::beginTag('div', ['class' => [$visibility,'hrzg-widget-content-frontend']]);
+                $html .= Html::beginTag('div', ['class' => [$visibility, 'hrzg-widget-content-frontend']]);
                 $html .= $class->run();
                 $html .= Html::endTag('div');
             }
@@ -408,7 +411,7 @@ JS
                 'aria-label' => \Yii::t('widgets', 'Toggle visibility status'),
                 'data' => [
                     'button' => 'loading',
-                    'loading-text' => FA::icon(FA::_SPINNER,['class' => 'fa-spin']),
+                    'loading-text' => FA::icon(FA::_SPINNER, ['class' => 'fa-spin']),
                     'html' => true
                 ]
             ],
@@ -428,7 +431,7 @@ JS
                     'data' => [
                         'method' => 'delete',
                         'confirm' => \Yii::t('widgets', 'Are you sure to delete this translation?'),
-                        'pjax'=> '0',
+                        'pjax' => '0',
                         'params' => [
                             'returnUrl' => Url::to('')
                         ]
@@ -447,7 +450,7 @@ JS
                         'data' => [
                             'method' => 'delete',
                             'confirm' => \Yii::t('widgets', 'Are you sure to delete this translation?'),
-                            'pjax'=> '0',
+                            'pjax' => '0',
                             'params' => [
                                 'returnUrl' => Url::to('')
                             ]

--- a/src/widgets/Cell.php
+++ b/src/widgets/Cell.php
@@ -24,7 +24,6 @@ use yii\caching\TagDependency;
 use yii\helpers\Html;
 use yii\helpers\Json;
 use yii\helpers\Url;
-use yii\helpers\VarDumper;
 
 /**
  * Class Cell
@@ -117,8 +116,8 @@ class Cell extends Widget implements ContextMenuItemsInterface
 
     /**
      * @inheritdoc
-     * @return string
      * @throws \yii\base\InvalidConfigException
+     * @return string
      */
     public function run()
     {
@@ -245,9 +244,9 @@ class Cell extends Widget implements ContextMenuItemsInterface
     }
 
     /**
-     * @return string
      * @throws \yii\base\InvalidConfigException
      * @throws \Exception
+     * @return string
      */
     private function renderWidgets()
     {
@@ -296,8 +295,8 @@ class Cell extends Widget implements ContextMenuItemsInterface
     }
 
     /**
-     * @return string
      * @throws \Exception
+     * @return string
      */
     private function generateCellControls()
     {
@@ -349,8 +348,8 @@ class Cell extends Widget implements ContextMenuItemsInterface
     /**
      * @param $widget
      *
-     * @return string
      * @throws \Exception
+     * @return string
      */
     private function generateWidgetControls(WidgetContent $widget)
     {
@@ -497,8 +496,8 @@ JS
     /**
      * @param $widget
      *
-     * @return boolean
      * @throws \Exception
+     * @return boolean
      */
     private function checkPublicationStatus($widget)
     {


### PR DESCRIPTION
This PR fixes some Bugs which occurred during testing and debugging

[1.](https://github.com/dmstr/yii2-widgets2-module/commit/4a5394b9f1d5019a2858cdfe60ba2a331b88c38c) There was no model rule for the `status` property in the `WidgetContent` model.
[2.](https://github.com/dmstr/yii2-widgets2-module/commit/6a0c56a61405d9e69fce5d19a904851d29441e89) Due to Bug 1. the provider for the `status` columns in the overview and detail view throw an `Undefined array key` if someone set the status to something we do not expect 
[3.](https://github.com/dmstr/yii2-widgets2-module/commit/1698f242fdb4f2b0de12238c4f9dc03b1e1de76f) JSON Schemas with only one type e.g.: `{"type": "string"}` lead to an array which crashes the whole page in which the cell is rendered in. To fix that, we want the properties to always be of type array. Value of a single type schemas are [made available via “value”](https://github.com/dmstr/yii2-widgets2-module/commit/aadb3b9f465c4f6873361c8dbe529981324141a0).