### PR TITLE
make requestParamName used in WidgetContent::getFrontendRoute configurable

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -56,11 +56,45 @@ class Module extends \yii\base\Module
     public $timezone = 'UTC';
 
     /**
-     * @var array mappings for links
+     * mappings for links
+     *
+     * can be used to map route and requestParam attributes from WidgetContent
+     * Models to frontend URLs
+     *
+     * the elements can be
+     * - simple string to string mappings
+     * - string to array mappings where route and requestParam Name can be defined
+     *
+     * example:
+     *  ```php
+     *  [
+     *    'app/site/index' => '/',
+     *    'pages/default/page' => 'pages/default/page',
+     *     'frontend/tag/detail' => [
+     *          'route' => 'frontend/tag/detail',
+     *          'requestParamName' => 'tagId',
+     *     ],
+     *  ]
+     *  ```
+     *
+     * @see \hrzg\widget\models\crud\WidgetContent::getFrontendRoute
+     * @var array
      */
     public $frontendRouteMap = [
         'app/site/index' => '/',
     ];
+
+    /**
+     * default name used as RequestParamName when generating frontend URLs
+     * can be overwritten for each route in self::$frontendRouteMap
+     *
+     * BC: define 'pageId' as default
+     *
+     * @see self::$frontendRouteMap
+     * @see \hrzg\widget\models\crud\WidgetContent::getFrontendRoute
+     * @var string
+     */
+    public $frontendDefaultRequestParamName = 'pageId';
 
     /**
      * set ajax option for JsonEditor

--- a/src/models/crud/WidgetContent.php
+++ b/src/models/crud/WidgetContent.php
@@ -282,14 +282,32 @@ class WidgetContent extends BaseWidget
     public function getFrontendRoute()
     {
         $mapping = \Yii::$app->controller->module->frontendRouteMap[$this->route] ?? false;
-
         if ($mapping) {
-            return Url::to(
-                [
-                    '/' . $mapping,
-                    'pageId' => $this->request_param,
-                    '#' => 'widget-' . $this->domain_id
-                ]);
+            // init params
+            $route = null;
+            // BC for <= 2.7.4: define 'pageId' as default paramName if not defined in Modul or in frontendRouteMap
+            $requestParamName = \Yii::$app->controller->module->frontendDefaultRequestParamName ?? 'pageId';
+            // simple route mapping
+            if (is_string($mapping)) {
+                $route = ltrim($mapping, '/');
+            }
+            // route and (optional) requestParamName mapping via array
+            if (is_array($mapping)) {
+                if (!empty($mapping['route']) && is_string($mapping['route'])) {
+                    $route = ltrim($mapping['route'], '/');
+                }
+                if (!empty($mapping['requestParamName']) && is_string($mapping['requestParamName'])) {
+                    $requestParamName = $mapping['requestParamName'];
+                }
+            }
+            if ($route) {
+                return Url::to(
+                    [
+                        '/' . $route,
+                        $requestParamName => $this->request_param,
+                        '#' => 'widget-' . $this->domain_id
+                    ]);
+            }
         }
 
         return false;


### PR DESCRIPTION
Currently, only a simple _route 2 route_ mapping for "view in frontend" links generated in `models\crud\WidgetContent::getFrontendRoute` can be defined via `Module::frontendRouteMap`.
However, the requestParamName is hardcoded to `pageId`.

This PR:
- allows the default (_pageId_) to be overloaded via `Module::frontendDefaultRequestParamName`
- to define the `requestParamName` per route in `Module::frontendRouteMap` via subarray.

If the new "features" are not used, the behavior is 1:1 as before the change.