### PR TITLE
hrzg-widget-container-controls css: raise z-index if we have open chi…

### DIFF
--- a/src/assets/web/widgets.less
+++ b/src/assets/web/widgets.less
@@ -60,6 +60,9 @@
     position: absolute;
     right: 0;
     z-index: 1098;
+    &:has(.open) {
+      z-index: 1100;
+    }
     button {
       z-index: 1099;
     }


### PR DESCRIPTION
This small PR raise the z-index for hrzg-widget-container-controls with opened child to ensure the opened child dropdown is displayed in front of other container-controls.

The "fixed" problem can be reproduced e.g. with multiple empty cells.
- click the top container-controls btn to open the template dropdown
- move the mouse down so that it is over the next cell
-> the open dropdown is not in front anymore.