### PR TITLE
feat(widgets): generic jsonEditorConfig (array|callable) passthrough for JsonEditorWidget

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -106,24 +106,58 @@ class Module extends \yii\base\Module
     /**
      * Extra options merged into every JsonEditorWidget rendered by this module's
      * edit forms. Generic passthrough so the module stays agnostic of any concrete
-     * editor plugin (file manager, WYSIWYG, ...). The array is deep-merged onto the
+     * editor plugin (file manager, WYSIWYG, ...). The result is deep-merged onto the
      * view's defaults (values here win), so it can set top-level widget options
      * (e.g. `flysystemRestConfig`, `registerJoditAsset`) as well as override
      * `clientOptions`.
      *
+     * May be either a plain array (static config) or a callable resolved at render
+     * time. Use a callable for anything runtime-dependent — a per-user JWT token,
+     * `Url::to()` (routing context is ready then, unlike in the config literal), or
+     * config that depends on the current model/schema. The callable receives the
+     * WidgetContent model and the decoded schema and must return an array:
+     * `function ($model, $schema): array`.
+     *
      * Example (application config):
      * ```php
+     * // static
      * 'jsonEditorConfig' => [
      *     'flysystemRestConfig' => [
      *         'apiBaseUrl'      => '/filemanager/api',
      *         'imageExtensions' => ['jpg', 'jpeg', 'gif', 'svg', 'png', 'bmp'],
      *     ],
      * ],
+     * // or dynamic (e.g. JWT auth mode)
+     * 'jsonEditorConfig' => function ($model, $schema) {
+     *     return [
+     *         'flysystemRestConfig' => [
+     *             'apiBaseUrl' => \yii\helpers\Url::to(['/filemanager/api']),
+     *             'jwt'        => Yii::$app->myJwtIssuer->tokenFor(Yii::$app->user->id),
+     *         ],
+     *     ];
+     * },
      * ```
      *
-     * @var array
+     * @var array|callable
+     * @see resolveJsonEditorConfig()
      */
     public $jsonEditorConfig = [];
+
+    /**
+     * Resolve {@see $jsonEditorConfig} to an array, invoking it if it is a callable.
+     *
+     * @param mixed $model  the WidgetContent model being edited (passed to the callable)
+     * @param mixed $schema the decoded JSON schema (passed to the callable)
+     * @return array the extra JsonEditorWidget options
+     */
+    public function resolveJsonEditorConfig($model = null, $schema = null): array
+    {
+        $config = $this->jsonEditorConfig;
+        if (is_callable($config)) {
+            $config = call_user_func($config, $model, $schema);
+        }
+        return is_array($config) ? $config : [];
+    }
 
 
     /**

--- a/src/Module.php
+++ b/src/Module.php
@@ -103,6 +103,28 @@ class Module extends \yii\base\Module
      */
     public $allowAjaxInSchema = false;
 
+    /**
+     * Extra options merged into every JsonEditorWidget rendered by this module's
+     * edit forms. Generic passthrough so the module stays agnostic of any concrete
+     * editor plugin (file manager, WYSIWYG, ...). The array is deep-merged onto the
+     * view's defaults (values here win), so it can set top-level widget options
+     * (e.g. `flysystemRestConfig`, `registerJoditAsset`) as well as override
+     * `clientOptions`.
+     *
+     * Example (application config):
+     * ```php
+     * 'jsonEditorConfig' => [
+     *     'flysystemRestConfig' => [
+     *         'apiBaseUrl'      => '/filemanager/api',
+     *         'imageExtensions' => ['jpg', 'jpeg', 'gif', 'svg', 'png', 'bmp'],
+     *     ],
+     * ],
+     * ```
+     *
+     * @var array
+     */
+    public $jsonEditorConfig = [];
+
 
     /**
      * If true, the json content properties will be validated against the json schema from the widget_template.

--- a/src/views/crud/widget-translation/_form.php
+++ b/src/views/crud/widget-translation/_form.php
@@ -91,7 +91,7 @@ $userAuthItems = $model::getUsersAuthItems();
 
             <?php \yii\widgets\Pjax::begin(['id' => 'pjax-widget-form']) ?>
             <?= $form->field($model, 'default_properties_json')->label(false)
-                ->widget(\dmstr\jsoneditor\JsonEditorWidget::class, [
+                ->widget(\dmstr\jsoneditor\JsonEditorWidget::class, \yii\helpers\ArrayHelper::merge([
                     'id' => 'editor',
                     'schema' => $schema,
                     'clientOptions' => [
@@ -100,7 +100,7 @@ $userAuthItems = $model::getUsersAuthItems();
                         'disable_properties' => true,
                         'keep_oneof_values' => false
                     ],
-                ]); ?>
+                ], Module::getInstance()->jsonEditorConfig)); ?>
             <?php \yii\widgets\Pjax::end() ?>
 
         </div>

--- a/src/views/crud/widget-translation/_form.php
+++ b/src/views/crud/widget-translation/_form.php
@@ -100,7 +100,7 @@ $userAuthItems = $model::getUsersAuthItems();
                         'disable_properties' => true,
                         'keep_oneof_values' => false
                     ],
-                ], Module::getInstance()->jsonEditorConfig)); ?>
+                ], Module::getInstance()->resolveJsonEditorConfig($model, $schema))); ?>
             <?php \yii\widgets\Pjax::end() ?>
 
         </div>

--- a/src/views/crud/widget/_form.php
+++ b/src/views/crud/widget/_form.php
@@ -115,7 +115,7 @@ JS;
 
             <?php \yii\widgets\Pjax::begin(['id' => 'pjax-widget-form']) ?>
             <?= $form->field($model, 'default_properties_json')->label(false)
-                ->widget(\dmstr\jsoneditor\JsonEditorWidget::className(), [
+                ->widget(\dmstr\jsoneditor\JsonEditorWidget::className(), \yii\helpers\ArrayHelper::merge([
                     'id' => 'editor',
                     'schema' => $schema,
                     'clientOptions' => [
@@ -128,7 +128,7 @@ JS;
                         'expand_height' => true,
                         'ajax' => !empty(\Yii::$app->controller->module->allowAjaxInSchema) ? true : false,
                     ],
-                ]); ?>
+                ], Module::getInstance()->jsonEditorConfig)); ?>
             <?php \yii\widgets\Pjax::end() ?>
 
         </div>

--- a/src/views/crud/widget/_form.php
+++ b/src/views/crud/widget/_form.php
@@ -128,7 +128,7 @@ JS;
                         'expand_height' => true,
                         'ajax' => !empty(\Yii::$app->controller->module->allowAjaxInSchema) ? true : false,
                     ],
-                ], Module::getInstance()->jsonEditorConfig)); ?>
+                ], Module::getInstance()->resolveJsonEditorConfig($model, $schema))); ?>
             <?php \yii\widgets\Pjax::end() ?>
 
         </div>


### PR DESCRIPTION
## Summary

Adds a generic way to configure the `JsonEditorWidget` rendered by this module's edit forms, so wiring an editor plugin (e.g. the `flysystem-rest` file picker) no longer requires hardcoding plugin-specific config into this generic module's views.

## Motivation

The edit forms rendered the widget with a fixed option set. Adding e.g. a file-manager config meant editing the view directly (and coupling this generic module to a concrete file manager). Configuration should come from the application.

## Change

- **`Module::$jsonEditorConfig`** (`array|callable`, default `[]`): extra options deep-merged (`ArrayHelper::merge`, config wins) onto the widget options in both edit forms — can set top-level widget options (`flysystemRestConfig`, `registerJoditAsset`, …) and override `clientOptions`.
- **`Module::resolveJsonEditorConfig($model, $schema)`**: resolves the value, invoking it if it is a callable.
- `widget/_form.php` and `widget-translation/_form.php` merge the resolved config into the widget options.

### array or callable?

Both are supported. Use a plain **array** for static config; use a **callable** `function ($model, $schema): array` for anything runtime-dependent — a per-user JWT token, `Url::to()` (routing context is ready at render time, unlike in the config literal), or config that varies by model/schema.

## Usage (application config)

```php
'modules' => [
    'widgets' => [
        'class' => \hrzg\widget\Module::class,
        // static
        'jsonEditorConfig' => [
            'flysystemRestConfig' => [
                'apiBaseUrl'      => '/filemanager/api',
                'imageExtensions' => ['jpg','jpeg','gif','svg','png','bmp'],
            ],
        ],
        // or dynamic
        // 'jsonEditorConfig' => function ($model, $schema) {
        //     return ['flysystemRestConfig' => ['jwt' => /* per-user token */]];
        // },
    ],
],
```

## Compatibility

Backward compatible — default `[]` changes nothing for existing installs; the forms render exactly as before when unset.

## Testing

- `php -l` on all changed files: passes.
- Not yet exercised end-to-end against a running backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)